### PR TITLE
refactor: Util.java에서 사용하지 않는 상수 제거

### DIFF
--- a/LogMonitoringProject/src/com/logmonitoring/common/Util.java
+++ b/LogMonitoringProject/src/com/logmonitoring/common/Util.java
@@ -16,15 +16,9 @@ public class Util {
 	public static final String url="172.22.1.66";
 	public static final String id="jsb568";
 	public static final String password="1234";
-	public static final int FILE_NAME = 0;
-	public static final int FILE_POINTER = 1;
 	public static final int MINUTE = 0;
 	public static final int HOUR = 1;
 	public static final int DAY = 2;
-	public static final int MINUTE_FRONT_POSITION = 10;
-	public static final int MINUTE_LAST_POSITION = 12;
-	public static final int MINUTE_FILE_NAME_LENGTH = 16;
-	public static final int HOUR_FILE_NAME_LENGTH = 14;
 	public static final String[] TIME_FILE_DIR = {MINUTE_FILE_DIR, HOUR_FILE_DIR, DAY_FILE_DIR};
 	public static final String[] MONITORING_FILE_DIR = {ACCESS_FILE_DIR, MINUTE_FILE_DIR, HOUR_FILE_DIR, DAY_FILE_DIR};
 	public static final String[] TRACE_FILE_DIR = {LOCAL_FILE_DIR + "minute_trace.txt",LOCAL_FILE_DIR + "hour_trace.txt",LOCAL_FILE_DIR + "day_trace.txt"};


### PR DESCRIPTION
## 개요
이슈 #2 에서 제안된 대로 Util.java 파일에서 사용되지 않는 상수들을 제거합니다.

## 변경 사항
다음 6개의 상수를 제거했습니다:
- `FILE_NAME` (값: 0) - 프로젝트 전체에서 참조되지 않음
- `FILE_POINTER` (값: 1) - 프로젝트 전체에서 참조되지 않음
- `MINUTE_FRONT_POSITION` (값: 10) - 프로젝트 전체에서 참조되지 않음
- `MINUTE_LAST_POSITION` (값: 12) - 프로젝트 전체에서 참조되지 않음
- `MINUTE_FILE_NAME_LENGTH` (값: 16) - 프로젝트 전체에서 참조되지 않음
- `HOUR_FILE_NAME_LENGTH` (값: 14) - 프로젝트 전체에서 참조되지 않음

## 검증 방법
GitHub 코드 검색을 통해 각 상수가 프로젝트 내 다른 파일에서 사용되지 않음을 확인했습니다.

## 기대 효과
- 코드 가독성 향상
- 유지보수 용이성 증대
- 불필요한 코드 제거로 인한 코드베이스 단순화

Closes #2